### PR TITLE
Fix "container does not reference a native integer" in test

### DIFF
--- a/t/02-messages.rakutest
+++ b/t/02-messages.rakutest
@@ -65,7 +65,7 @@ sub to-hex(buf8 $buffer) {
 	my Str $result = '';
 
 	for ^$buffer.elems -> $pos {
-		my int $byte = $buffer[$pos];
+		my uint8 $byte = $buffer[$pos];
 		$result ~= ($byte +> 4).fmt("%x") ~ ($byte % 16).fmt("%x");
 	}
 	return $result;


### PR DESCRIPTION
`buf8` is a `Buf[uint8]`, i.e. a Buf containing unsigned 8 bit integers. Thus we need to
read unsigned integers from it. This fix is required on Rakudo versions with fixed uint
handling and is backwards compatible (since old Rakudo didn't care about int vs uint)